### PR TITLE
[feat] 회원 정보 수정 api 연결

### DIFF
--- a/core/data/src/main/java/com/ds/studify/core/data/datasource/UserDataSource.kt
+++ b/core/data/src/main/java/com/ds/studify/core/data/datasource/UserDataSource.kt
@@ -1,0 +1,22 @@
+package com.ds.studify.core.data.datasource
+
+import com.ds.studify.core.data.dto.request.ProfileDto
+import com.ds.studify.core.data.dto.request.RequestChangeNicknameDto
+import com.ds.studify.core.data.dto.request.RequestChangePasswordDto
+import com.ds.studify.core.data.dto.response.BaseResponse
+import com.ds.studify.core.data.service.UserService
+import kotlinx.serialization.json.JsonElement
+import javax.inject.Inject
+
+class  UserDataSource @Inject constructor(
+    private val service: UserService
+) {
+    suspend fun getProfile(): BaseResponse<ProfileDto> =
+        service.getProfile()
+
+    suspend fun patchChangePassword(body: RequestChangePasswordDto): BaseResponse<JsonElement?> =
+        service.patchChangePassword(body)
+
+    suspend fun patchChangeNickname(body: RequestChangeNicknameDto): BaseResponse<ProfileDto> =
+        service.patchChangeNickname(body)
+}

--- a/core/data/src/main/java/com/ds/studify/core/data/di/UserDataModule.kt
+++ b/core/data/src/main/java/com/ds/studify/core/data/di/UserDataModule.kt
@@ -1,0 +1,32 @@
+package com.ds.studify.core.data.di
+
+import com.ds.studify.core.data.di.qualifier.JWT
+import com.ds.studify.core.data.repository.UserRepository
+import com.ds.studify.core.data.repository_impl.UserRepositoryImpl
+import com.ds.studify.core.data.service.UserService
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class UserBindModule {
+    @Binds
+    @Singleton
+    abstract fun bindUserRepository(impl: UserRepositoryImpl): UserRepository
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object UserProvideModule {
+    @Provides
+    @Singleton
+    fun provideUserService(
+        @JWT retrofit: Retrofit
+    ): UserService =
+        retrofit.create(UserService::class.java)
+}

--- a/core/data/src/main/java/com/ds/studify/core/data/dto/request/ProfileDto.kt
+++ b/core/data/src/main/java/com/ds/studify/core/data/dto/request/ProfileDto.kt
@@ -1,0 +1,9 @@
+package com.ds.studify.core.data.dto.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ProfileDto(
+    val email: String,
+    val nickname: String
+)

--- a/core/data/src/main/java/com/ds/studify/core/data/dto/request/RequestChangeNicknameDto.kt
+++ b/core/data/src/main/java/com/ds/studify/core/data/dto/request/RequestChangeNicknameDto.kt
@@ -1,0 +1,10 @@
+package com.ds.studify.core.data.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestChangeNicknameDto(
+    @SerialName("newNickname")
+    val nickname: String
+)

--- a/core/data/src/main/java/com/ds/studify/core/data/dto/request/RequestChangePasswordDto.kt
+++ b/core/data/src/main/java/com/ds/studify/core/data/dto/request/RequestChangePasswordDto.kt
@@ -1,0 +1,9 @@
+package com.ds.studify.core.data.dto.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestChangePasswordDto(
+    val originPassword: String,
+    val newPassword: String
+)

--- a/core/data/src/main/java/com/ds/studify/core/data/repository/UserRepository.kt
+++ b/core/data/src/main/java/com/ds/studify/core/data/repository/UserRepository.kt
@@ -1,0 +1,9 @@
+package com.ds.studify.core.data.repository
+
+import com.ds.studify.core.domain.entity.ProfileEntity
+
+interface UserRepository {
+    suspend fun getProfile(): Result<ProfileEntity>
+    suspend fun patchChangePassword(originPassword: String, newPassword: String): Result<Unit>
+    suspend fun patchChangeNickname(nickname: String): Result<ProfileEntity>
+}

--- a/core/data/src/main/java/com/ds/studify/core/data/repository_impl/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ds/studify/core/data/repository_impl/UserRepositoryImpl.kt
@@ -1,0 +1,55 @@
+package com.ds.studify.core.data.repository_impl
+
+import com.ds.studify.core.data.datasource.UserDataSource
+import com.ds.studify.core.data.dto.request.RequestChangeNicknameDto
+import com.ds.studify.core.data.dto.request.RequestChangePasswordDto
+import com.ds.studify.core.data.repository.UserRepository
+import com.ds.studify.core.domain.entity.ProfileEntity
+import javax.inject.Inject
+
+class UserRepositoryImpl @Inject constructor(
+    private val dataSource: UserDataSource
+) : UserRepository {
+
+    override suspend fun getProfile(): Result<ProfileEntity> = runCatching {
+        val res = dataSource.getProfile()
+        if (res.status.toInt() == 200 || res.code == "SUCCESS_PROFILE") {
+            val dto = res.data
+            ProfileEntity(email = dto.email, nickname = dto.nickname)
+        } else {
+            error(res.message)
+        }
+    }
+
+    override suspend fun patchChangePassword(originPassword: String, newPassword: String): Result<Unit> =
+        runCatching {
+            val res = dataSource.patchChangePassword(
+                RequestChangePasswordDto(originPassword, newPassword)
+            )
+            when {
+                res.status.toInt() == 200 || res.code == "SUCCESS_CHANGE_PASSWORD" -> Unit
+                res.status.toInt() == 403 || res.code == "INCORRECT_PASSWORD" -> error("INCORRECT_PASSWORD")
+                else -> error(res.message)
+            }
+        }
+
+    override suspend fun patchChangeNickname(nickname: String): Result<ProfileEntity> = runCatching {
+        return try {
+            val res = dataSource.patchChangeNickname(RequestChangeNicknameDto(nickname))
+            if (res.status.toInt() == 200 || res.code == "SUCCESS_CHANGE_NICKNAME") {
+                val dto = res.data
+                Result.success(ProfileEntity(email = dto.email, nickname = dto.nickname))
+            } else {
+                Result.failure(IllegalStateException(res.message))
+            }
+        } catch (e: retrofit2.HttpException) {
+            if (e.code() == 403) {
+                Result.failure(IllegalStateException("NICKNAME_FORBIDDEN"))
+            } else {
+                Result.failure(e)
+            }
+        } catch (e: Throwable) {
+            Result.failure(e)
+        }
+    }
+}

--- a/core/data/src/main/java/com/ds/studify/core/data/service/UserService.kt
+++ b/core/data/src/main/java/com/ds/studify/core/data/service/UserService.kt
@@ -1,0 +1,26 @@
+package com.ds.studify.core.data.service
+
+import com.ds.studify.core.data.dto.request.ProfileDto
+import com.ds.studify.core.data.dto.request.RequestChangeNicknameDto
+import com.ds.studify.core.data.dto.request.RequestChangePasswordDto
+import com.ds.studify.core.data.dto.response.BaseResponse
+import kotlinx.serialization.json.JsonElement
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+
+interface UserService {
+
+    @GET("user/profile")
+    suspend fun getProfile(): BaseResponse<ProfileDto>
+
+    @PATCH("user/change-password")
+    suspend fun patchChangePassword(
+        @Body body: RequestChangePasswordDto
+    ): BaseResponse<JsonElement?>
+
+    @PATCH("user/change-nickname")
+    suspend fun patchChangeNickname(
+        @Body body: RequestChangeNicknameDto
+    ): BaseResponse<ProfileDto>
+}

--- a/core/domain/src/main/java/com/ds/studify/core/domain/entity/ProfileEntity.kt
+++ b/core/domain/src/main/java/com/ds/studify/core/domain/entity/ProfileEntity.kt
@@ -1,0 +1,6 @@
+package com.ds.studify.core.domain.entity
+
+data class ProfileEntity(
+    val email: String,
+    val nickname: String
+)

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="mypage_change">변경하기</string>
     <string name="mypage_change_success">성공적으로 변경되었습니다.</string>
     <string name="mypage_change_failed">변경에 실패하였습니다.</string>
+    <string name="mypage_change_nickname_forbidden">닉네임을 변경할 수 없습니다.</string>
 
     <!--  로그인 및 회원가입  -->
     <string name="login_description">AI 분석을 통한 학습 관리 도우미</string>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="mypage_change_success">성공적으로 변경되었습니다.</string>
     <string name="mypage_change_failed">변경에 실패하였습니다.</string>
     <string name="mypage_change_nickname_forbidden">닉네임을 변경할 수 없습니다.</string>
+    <string name="mypage_profile_load_failed">회원 정보를 불러오지 못했습니다.</string>
 
     <!--  로그인 및 회원가입  -->
     <string name="login_description">AI 분석을 통한 학습 관리 도우미</string>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -89,9 +89,11 @@
     <string name="mypage_menu_change_password">비밀번호 변경</string>
     <string name="mypage_menu_change_nickname">닉네임 변경</string>
     <string name="mypage_logout">로그아웃</string>
-    <string name="mypage_edit_profile_title">회원정보 수정</string>
+    <string name="mypage_edit_profile_title">회원 정보 수정</string>
     <string name="mypage_edit_password_label">현재 비밀번호</string>
     <string name="mypage_change">변경하기</string>
+    <string name="mypage_change_success">성공적으로 변경되었습니다.</string>
+    <string name="mypage_change_failed">변경에 실패하였습니다.</string>
 
     <!--  로그인 및 회원가입  -->
     <string name="login_description">AI 분석을 통한 학습 관리 도우미</string>

--- a/feature/mypage/build.gradle.kts
+++ b/feature/mypage/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(projects.core.designsystem)
     implementation(projects.core.resources)
     implementation(projects.core.uiExtension)
+    implementation(projects.core.domain)
 
     implementation(libs.bundles.orbit)
 }

--- a/feature/mypage/src/main/java/com/ds/studify/feature/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/com/ds/studify/feature/mypage/MyPageScreen.kt
@@ -47,11 +47,30 @@ internal fun MyPageRoute(
 ) {
     val viewModel: MyPageViewModel = hiltViewModel()
     val uiState by viewModel.collectAsState()
+    val context = androidx.compose.ui.platform.LocalContext.current
+
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+                viewModel.refreshProfile()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     viewModel.collectSideEffect {
         when (it) {
-            is MyPageSideEffect.LogoutSuccess -> {
-                navigationDelegator.onLogoutClick()
+            is MyPageSideEffect.LogoutSuccess -> navigationDelegator.onLogoutClick()
+            is MyPageSideEffect.Toast -> {
+                android.widget.Toast
+                    .makeText(
+                        context,
+                        context.getString(it.resId),
+                        android.widget.Toast.LENGTH_SHORT
+                    )
+                    .show()
             }
         }
     }
@@ -140,7 +159,7 @@ internal fun MyPageScreen(
                         )
                     }
                     Text(
-                        text = "abcd123@gmail.com",
+                        text = uiState.email,
                         color = StudifyColors.WHITE,
                         style = Typography.bodySmall,
                         modifier = Modifier.padding(top = 8.dp)
@@ -238,7 +257,7 @@ internal fun MyPageScreen(
 private fun MyPageScreenPreview() {
     MyPageScreen(
         paddingValues = PaddingValues(0.dp),
-        uiState = MyPageUiState.MyPage(userName = "닉네임"),
+        uiState = MyPageUiState.MyPage(userName = "닉네임", email = "abcd123@gmail.com"),
         onEvent = {},
         onPasswordChangeClick = {},
         onNicknameChangeClick = {}

--- a/feature/mypage/src/main/java/com/ds/studify/feature/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/ds/studify/feature/mypage/MyPageViewModel.kt
@@ -2,6 +2,8 @@ package com.ds.studify.feature.mypage
 
 import androidx.lifecycle.ViewModel
 import com.ds.studify.core.data.repository.TokenRepository
+import com.ds.studify.core.data.repository.UserRepository
+import com.ds.studify.core.resources.StudifyString
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
@@ -10,7 +12,8 @@ import javax.inject.Inject
 sealed interface MyPageUiState {
     data object Loading : MyPageUiState
     data class MyPage(
-        val userName: String
+        val userName: String,
+        val email: String
     ) : MyPageUiState
 }
 
@@ -20,18 +23,33 @@ sealed interface MyPageUiEvent {
 
 sealed interface MyPageSideEffect {
     data object LogoutSuccess : MyPageSideEffect
+    data class Toast(@androidx.annotation.StringRes val resId: Int) : MyPageSideEffect
 }
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
-    private val tokenRepository: TokenRepository
+    private val tokenRepository: TokenRepository,
+    private val userRepository: UserRepository
 ) : ViewModel(), ContainerHost<MyPageUiState, MyPageSideEffect> {
 
     override val container = container<MyPageUiState, MyPageSideEffect>(
         initialState = MyPageUiState.Loading
     ) {
-        reduce {
-            MyPageUiState.MyPage(userName = "닉네임")
+        refreshProfile()
+    }
+
+    fun refreshProfile() = intent {
+        val result = userRepository.getProfile()
+        result.onSuccess { profile ->
+            reduce { MyPageUiState.MyPage(userName = profile.nickname, email = profile.email) }
+        }.onFailure {
+            reduce {
+                when (val s = state) {
+                    is MyPageUiState.MyPage -> s
+                    else -> MyPageUiState.MyPage(userName = "닉네임", email = "")
+                }
+            }
+            postSideEffect(MyPageSideEffect.Toast(StudifyString.mypage_profile_load_failed))
         }
     }
 

--- a/feature/mypage/src/main/java/com/ds/studify/feature/mypage/NicknameChangeScreen.kt
+++ b/feature/mypage/src/main/java/com/ds/studify/feature/mypage/NicknameChangeScreen.kt
@@ -39,6 +39,7 @@ import com.ds.studify.core.designsystem.theme.StudifyColors
 import com.ds.studify.core.designsystem.theme.Typography
 import com.ds.studify.core.resources.StudifyString
 import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 import kotlin.math.max
 
 @Composable
@@ -47,6 +48,20 @@ internal fun NicknameChangeRoute(
     viewModel: NicknameChangeViewModel = hiltViewModel()
 ) {
     val uiState = viewModel.collectAsState().value
+    val context = androidx.compose.ui.platform.LocalContext.current
+
+    viewModel.collectSideEffect { effect ->
+        when (effect) {
+            is NicknameChangeSideEffect.Toast ->
+                android.widget.Toast.makeText(
+                    context,
+                    context.getString(effect.resId),
+                    android.widget.Toast.LENGTH_SHORT
+                ).show()
+
+            NicknameChangeSideEffect.NavigateBack -> onBack()
+        }
+    }
 
     StudifyScaffoldWithTitle(
         title = stringResource(id = StudifyString.mypage_edit_profile_title),

--- a/feature/mypage/src/main/java/com/ds/studify/feature/mypage/NicknameChangeViewModel.kt
+++ b/feature/mypage/src/main/java/com/ds/studify/feature/mypage/NicknameChangeViewModel.kt
@@ -2,6 +2,7 @@ package com.ds.studify.feature.mypage
 
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
+import com.ds.studify.core.data.repository.UserRepository
 import com.ds.studify.core.resources.StudifyString
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.ContainerHost
@@ -17,11 +18,13 @@ data class NicknameChangeUiState(
 }
 
 sealed interface NicknameChangeSideEffect {
+    data class Toast(@StringRes val resId: Int) : NicknameChangeSideEffect
     data object NavigateBack : NicknameChangeSideEffect
 }
 
 @HiltViewModel
 class NicknameChangeViewModel @Inject constructor(
+    private val userRepository: UserRepository
 ) : ViewModel(), ContainerHost<NicknameChangeUiState, NicknameChangeSideEffect> {
 
     override val container = container<NicknameChangeUiState, NicknameChangeSideEffect>(
@@ -38,5 +41,34 @@ class NicknameChangeViewModel @Inject constructor(
             reduce { state.copy(nicknameErrorRes = StudifyString.auth_nickname_warning) }
             return@intent
         }
+        reduce { state.copy(isLoading = true) }
+
+        userRepository.patchChangeNickname(state.nickname)
+            .onSuccess {
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(
+                    NicknameChangeSideEffect.Toast(
+                        StudifyString.mypage_change_success
+                    )
+                )
+                postSideEffect(NicknameChangeSideEffect.NavigateBack)
+            }
+            .onFailure {
+                postSideEffect(
+                    NicknameChangeSideEffect.Toast(
+                        StudifyString.mypage_change_failed
+                    )
+                )
+                reduce { state.copy(isLoading = false) }
+            }
+            .onFailure { e ->
+                reduce { state.copy(isLoading = false) }
+                val resId =
+                    if (e.message == "NICKNAME_FORBIDDEN")
+                        StudifyString.mypage_change_nickname_forbidden
+                    else
+                        StudifyString.mypage_change_failed
+                postSideEffect(NicknameChangeSideEffect.Toast(resId))
+            }
     }
 }

--- a/feature/mypage/src/main/java/com/ds/studify/feature/mypage/PasswordChangeScreen.kt
+++ b/feature/mypage/src/main/java/com/ds/studify/feature/mypage/PasswordChangeScreen.kt
@@ -40,6 +40,7 @@ import com.ds.studify.core.designsystem.theme.StudifyColors
 import com.ds.studify.core.designsystem.theme.Typography
 import com.ds.studify.core.resources.StudifyString
 import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 import kotlin.math.max
 
 @Composable
@@ -48,6 +49,20 @@ internal fun PasswordChangeRoute(
     viewModel: PasswordChangeViewModel = hiltViewModel()
 ) {
     val uiState = viewModel.collectAsState().value
+    val context = androidx.compose.ui.platform.LocalContext.current
+
+    viewModel.collectSideEffect { effect ->
+        when (effect) {
+            is PasswordChangeSideEffect.Toast ->
+                android.widget.Toast.makeText(
+                    context,
+                    context.getString(effect.resId),
+                    android.widget.Toast.LENGTH_SHORT
+                ).show()
+
+            PasswordChangeSideEffect.NavigateBack -> onBack()
+        }
+    }
 
     StudifyScaffoldWithTitle(
         title = stringResource(id = StudifyString.mypage_edit_profile_title),

--- a/feature/mypage/src/main/java/com/ds/studify/feature/mypage/PasswordChangeViewModel.kt
+++ b/feature/mypage/src/main/java/com/ds/studify/feature/mypage/PasswordChangeViewModel.kt
@@ -2,6 +2,8 @@ package com.ds.studify.feature.mypage
 
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
+import com.ds.studify.core.data.repository.UserRepository
+import com.ds.studify.core.resources.StudifyString
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
@@ -25,13 +27,16 @@ data class PasswordChangeUiState(
 
 sealed interface PasswordChangeSideEffect {
     data object NavigateBack : PasswordChangeSideEffect
+    data class Toast(@StringRes val resId: Int) : PasswordChangeSideEffect
 }
 
 @HiltViewModel
 class PasswordChangeViewModel @Inject constructor(
+    private val userRepository: UserRepository
 ) : ViewModel(), ContainerHost<PasswordChangeUiState, PasswordChangeSideEffect> {
 
-    override val container = container<PasswordChangeUiState, PasswordChangeSideEffect>(PasswordChangeUiState())
+    override val container =
+        container<PasswordChangeUiState, PasswordChangeSideEffect>(PasswordChangeUiState())
 
     fun updateCurrentPassword(value: String) = intent {
         reduce { state.copy(currentPassword = value, currentPasswordErrorRes = null) }
@@ -47,5 +52,33 @@ class PasswordChangeViewModel @Inject constructor(
         reduce { state.copy(confirmPassword = value, isPasswordMatch = matched) }
     }
 
-    fun onChangeClick() = intent {}
+    fun onChangeClick() = intent {
+        if (!state.isChangeEnabled) return@intent
+        reduce { state.copy(isLoading = true, currentPasswordErrorRes = null) }
+
+        userRepository.patchChangePassword(
+            originPassword = state.currentPassword,
+            newPassword = state.newPassword
+        ).onSuccess {
+            reduce { state.copy(isLoading = false) }
+            postSideEffect(
+                PasswordChangeSideEffect.Toast(
+                    StudifyString.mypage_change_success
+                )
+            )
+            postSideEffect(PasswordChangeSideEffect.NavigateBack)
+        }.onFailure { e ->
+            val isIncorrect = e.message?.contains("INCORRECT_PASSWORD") == true
+            reduce {
+                state.copy(
+                    isLoading = false,
+                    currentPasswordErrorRes =
+                        if (isIncorrect)
+                            StudifyString.mypage_change_failed
+                        else
+                            StudifyString.auth_password_warning
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue
- Closes #53

## ✅ 작업 상세 내용
- 마이페이지 api 연결
- 비밀번호 변경 api 연결
- 닉네임 변경 api 연결
- 변경 성공 시, 마이페이지 이동 및 토스트 알림
- 변경 실패 시, 토스트 알림 또는 경고 안내
