### PR TITLE
[design] 상태 타임라인 핸드폰 가로 길이에 맞춰 조정

### DIFF
--- a/core/designsystem/src/main/java/com/ds/studify/core/designsystem/component/StateTimeline.kt
+++ b/core/designsystem/src/main/java/com/ds/studify/core/designsystem/component/StateTimeline.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -73,15 +72,12 @@ fun StateTimeline(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(500.dp)
             .clip(RoundedCornerShape(10.dp))
-            .background(color = StudifyColors.PK01),
-        contentAlignment = Alignment.Center
+            .background(color = StudifyColors.PK01)
+            .padding(start = 6.dp, end = 14.dp)
+            .padding(vertical = 12.dp)
     ) {
-        Row(
-            modifier = Modifier
-                .padding(end = 3.dp)
-        ) {
+        Row {
             Column(
                 modifier = Modifier
                     .height(430.dp)
@@ -91,26 +87,26 @@ fun StateTimeline(
             ) {
                 Text(
                     text = LocalDateTime.parse(startTime, isoFormatter).format(timeFormatter),
-                    style = Typography.bodySmall
+                    style = Typography.labelSmall
                 )
                 Text(
                     text = LocalDateTime.parse(endTime, isoFormatter).format(timeFormatter),
-                    style = Typography.bodySmall
+                    style = Typography.labelSmall
                 )
             }
+
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 (1..6).forEach { stateId ->
                     Column(
-                        modifier = Modifier
-                            .height(470.dp),
+                        modifier = Modifier.weight(1f),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.Top
                     ) {
                         Box(
                             modifier = Modifier
-                                .width(47.dp)
+                                .fillMaxWidth()
                                 .height(430.dp)
                                 .clip(RoundedCornerShape(10.dp))
                                 .background(color = StudifyColors.G01)

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -69,12 +69,12 @@
     <string name="analysis_state_timeline">상태 타임라인</string>
 
     <!-- 상태 타임라인 -->
-    <string name="state_1">공부 중</string>
+    <string name="state_1">공부</string>
     <string name="state_2">바른\n자세</string>
-    <string name="state_3">집중도\n저하 자세</string>
+    <string name="state_3">집중도\n저하</string>
     <string name="state_4">수면</string>
     <string name="state_5">자리\n비움</string>
-    <string name="state_6">기타</string>
+    <string name="state_6">공부\n중지</string>
 
     <!--  통계  -->
     <string name="stats_total_study_time">총 공부 시간</string>


### PR DESCRIPTION
## #️⃣ Issue
- Closed #66

## ✅ 작업 상세 내용
- 타임라인 가로 길이를 고정하지 않고, 핸드폰 가로 길이에 따라 조정되도록 수정
- 타임라인에 출력되는 상태명 수정: 공부 중 -> 공부 / 집중도 저하 자세 -> 집중도 저하 / 기타 -> 공부 중지

## 📸 스크린샷
<img src="https://github.com/user-attachments/assets/f9c5657d-6e92-45c0-8686-590186509091" width="200" />