### PR TITLE
[feat] 회원 정보 약관 추가

### DIFF
--- a/app/src/main/java/com/ds/studify/navigation/StudifyNavHost.kt
+++ b/app/src/main/java/com/ds/studify/navigation/StudifyNavHost.kt
@@ -28,7 +28,7 @@ import com.ds.studify.feature.mypage.navigation.navigateToNicknameChange
 import com.ds.studify.feature.mypage.navigation.navigateToPasswordChange
 import com.ds.studify.feature.signup.navigation.RouteSignup
 import com.ds.studify.feature.signup.navigation.navigateToSignup
-import com.ds.studify.feature.signup.navigation.signupScreen
+import com.ds.studify.feature.signup.navigation.signupGraph
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -72,7 +72,16 @@ fun StudifyNavHost(
                 )
             )
 
-            signupScreen(
+//            signupScreen(
+//                onNavigateLogin = {
+//                    navController.navigate(RouteLogin) {
+//                        popUpTo(RouteSignup) { inclusive = true }
+//                        launchSingleTop = true
+//                    }
+//                }
+//            )
+            signupGraph(
+                navController = navController,
                 onNavigateLogin = {
                     navController.navigate(RouteLogin) {
                         popUpTo(RouteSignup) { inclusive = true }

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -126,5 +126,10 @@
     <string name="signup_verification_code_failed_message">인증 번호 전송에 실패하였습니다.</string>
     <string name="signup_duplicate_email">이미 존재하는 이메일입니다.</string>
     <string name="signup_register_failed">회원가입에 실패하였습니다.</string>
+    <string name="signup_terms_agree_all">아래 내용에 모두 동의합니다.</string>
+    <string name="signup_terms_service">(필수) 서비스 이용약관</string>
+    <string name="signup_terms_privacy">(필수) 개인정보 처리방침</string>
+    <string name="signup_terms_age">(필수) 만 14세 이상입니다.</string>
+    <string name="signup_terms_view">보기</string>
 
 </resources>

--- a/feature/signup/src/main/java/com/ds/studify/feature/signup/SignupScreen.kt
+++ b/feature/signup/src/main/java/com/ds/studify/feature/signup/SignupScreen.kt
@@ -3,6 +3,7 @@ package com.ds.studify.feature.signup
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -27,6 +28,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
@@ -47,6 +50,7 @@ import com.ds.studify.core.designsystem.theme.StudifyColors
 import com.ds.studify.core.designsystem.theme.Typography
 import com.ds.studify.core.resources.StudifyDrawable
 import com.ds.studify.core.resources.StudifyString
+import com.ds.studify.feature.signup.navigation.TermsType
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 import kotlin.math.max
@@ -54,6 +58,7 @@ import kotlin.math.max
 @Composable
 internal fun SignupRoute(
     onNavigateLogin: () -> Unit,
+    onNavigateTerms: (TermsType) -> Unit,
     viewModel: SignupViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.collectAsState()
@@ -76,12 +81,15 @@ internal fun SignupRoute(
         updatePassword = viewModel::updatePassword,
         updateConfirmPassword = viewModel::updateConfirmPassword,
         updateNickname = viewModel::updateNickname,
+        onAgreementChanged = viewModel::onAgreementChanged,
+        onAllAgreementsChanged = viewModel::onAllAgreementsChanged,
         onSendVerificationClick = {
 //            if (uiState.showTimer) {
 //                viewModel.reverify()
 //            } else
                 viewModel.sendVerification()
         },
+        onNavigateTerms = onNavigateTerms,
         onSignupClick = { viewModel.onSignupClick() }
     )
 
@@ -96,7 +104,10 @@ internal fun SignupScreen(
     updatePassword: (String) -> Unit = {},
     updateConfirmPassword: (String) -> Unit = {},
     updateNickname: (String) -> Unit = {},
+    onAgreementChanged: (Boolean?, Boolean?, Boolean?) -> Unit = { _, _, _ -> },
+    onAllAgreementsChanged: (Boolean) -> Unit = {},
     onSendVerificationClick: () -> Unit = {},
+    onNavigateTerms: (TermsType) -> Unit = {},
     onSignupClick: () -> Unit = {}
 ) {
     val density = LocalDensity.current
@@ -346,6 +357,13 @@ internal fun SignupScreen(
                 Spacer(modifier = Modifier.height(12.dp))
             }
 
+            TermsAgreementSection(
+                uiState = uiState,
+                onAllAgreementsChanged = onAllAgreementsChanged,
+                onAgreementChanged = onAgreementChanged,
+                onNavigateTerms = onNavigateTerms
+            )
+
             Spacer(modifier = Modifier.height(24.dp))
 
             Button(
@@ -364,6 +382,95 @@ internal fun SignupScreen(
             }
 
             Spacer(modifier = Modifier.height(24.dp + extraScrollPaddingDp))
+        }
+    }
+}
+
+// 약관 전체
+@Composable
+private fun TermsAgreementSection(
+    uiState: SignupUiState,
+    onAllAgreementsChanged: (Boolean) -> Unit,
+    onAgreementChanged: (Boolean?, Boolean?, Boolean?) -> Unit,
+    onNavigateTerms: (TermsType) -> Unit
+) {
+    val areAllAgreed = uiState.isServiceTermsAgreed && uiState.isPrivacyPolicyAgreed && uiState.isAgeConfirmed
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(36.dp)
+                .clickable { onAllAgreementsChanged(!areAllAgreed) },
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Checkbox(
+                checked = areAllAgreed,
+                onCheckedChange = { onAllAgreementsChanged(it) },
+                colors = CheckboxDefaults.colors(checkedColor = StudifyColors.PK03),
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = stringResource(id = StudifyString.signup_terms_agree_all),
+                style = Typography.bodyMedium
+            )
+        }
+        AgreementItem(
+            checked = uiState.isServiceTermsAgreed,
+            onCheckedChange = { onAgreementChanged(it, null, null) },
+            text = stringResource(id = StudifyString.signup_terms_service),
+            onViewClick = { onNavigateTerms(TermsType.SERVICE) }
+        )
+        AgreementItem(
+            checked = uiState.isPrivacyPolicyAgreed,
+            onCheckedChange = { onAgreementChanged(null, it, null) },
+            text = stringResource(id = StudifyString.signup_terms_privacy),
+            onViewClick = { onNavigateTerms(TermsType.PRIVACY) }
+        )
+        AgreementItem(
+            checked = uiState.isAgeConfirmed,
+            onCheckedChange = { onAgreementChanged(null, null, it) },
+            text = stringResource(id = StudifyString.signup_terms_age),
+            onViewClick = null
+        )
+    }
+}
+
+// 각 약관 항목
+@Composable
+private fun AgreementItem(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    text: String,
+    onViewClick: (() -> Unit)? = null,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(28.dp)
+            .clickable { onCheckedChange(!checked) },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            colors = CheckboxDefaults.colors(checkedColor = StudifyColors.PK03),
+            modifier = Modifier.size(18.dp)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(text = text, style = Typography.bodySmall, modifier = Modifier.weight(1f))
+
+        val viewClick = onViewClick
+        if (viewClick != null) {
+            Text(
+                text = stringResource(id = StudifyString.signup_terms_view),
+                style = Typography.bodySmall,
+                color = StudifyColors.G03,
+                modifier = Modifier
+                    .clickable { viewClick() }
+                    .padding(start = 8.dp)
+            )
         }
     }
 }

--- a/feature/signup/src/main/java/com/ds/studify/feature/signup/SignupViewModel.kt
+++ b/feature/signup/src/main/java/com/ds/studify/feature/signup/SignupViewModel.kt
@@ -35,8 +35,15 @@ data class SignupUiState(
     val isLoading: Boolean = false,
 
     val resendSecondsLeft: Int = 0,
-    val registerSuccess: Boolean = false
+    val registerSuccess: Boolean = false,
+
+    val isServiceTermsAgreed: Boolean = false,
+    val isPrivacyPolicyAgreed: Boolean = false,
+    val isAgeConfirmed: Boolean = false
 ){
+    private val areAllConsentsProvided: Boolean =
+        isServiceTermsAgreed && isPrivacyPolicyAgreed && isAgeConfirmed
+
     val isSignupEnabled: Boolean =
         isEmailValid &&
         isPasswordMatch &&
@@ -44,7 +51,8 @@ data class SignupUiState(
         verificationCode.isNotBlank() &&
         password.isNotBlank() &&
         confirmPassword.isNotBlank() &&
-        nickname.isNotBlank()
+        nickname.isNotBlank() &&
+        areAllConsentsProvided
 
     // 타이머
     val showTimer: Boolean = resendSecondsLeft > 0
@@ -65,6 +73,31 @@ class SignupViewModel @Inject constructor(
     override val container = container<SignupUiState, SignupSideEffect>(SignupUiState())
 
     private var timerJob: Job? = null
+
+
+    fun onAgreementChanged(
+        serviceTerms: Boolean? = null,
+        privacyPolicy: Boolean? = null,
+        ageConfirmed: Boolean? = null
+    ) = intent {
+        reduce {
+            state.copy(
+                isServiceTermsAgreed = serviceTerms ?: state.isServiceTermsAgreed,
+                isPrivacyPolicyAgreed = privacyPolicy ?: state.isPrivacyPolicyAgreed,
+                isAgeConfirmed = ageConfirmed ?: state.isAgeConfirmed
+            )
+        }
+    }
+
+    fun onAllAgreementsChanged(agreed: Boolean) = intent {
+        reduce {
+            state.copy(
+                isServiceTermsAgreed = agreed,
+                isPrivacyPolicyAgreed = agreed,
+                isAgeConfirmed = agreed
+            )
+        }
+    }
 
     fun updateEmail(email: String) = intent {
         val isValid = email.matches(Regex(EMAIL_REGEX))

--- a/feature/signup/src/main/java/com/ds/studify/feature/signup/TermsWebViewScreen.kt
+++ b/feature/signup/src/main/java/com/ds/studify/feature/signup/TermsWebViewScreen.kt
@@ -1,0 +1,104 @@
+package com.ds.studify.feature.signup
+
+import android.annotation.SuppressLint
+import android.view.ViewGroup
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.navigation.toRoute
+import com.ds.studify.core.resources.StudifyString
+import com.ds.studify.feature.signup.navigation.RouteTerms
+import com.ds.studify.feature.signup.navigation.TermsType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+internal class TermsViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    private val termsRoute: RouteTerms = savedStateHandle.toRoute()
+    val termsType = termsRoute.type
+
+    val titleResId: Int
+        get() = when (termsType) {
+            TermsType.SERVICE -> StudifyString.signup_terms_service
+            TermsType.PRIVACY -> StudifyString.signup_terms_privacy
+        }
+
+    val url: String
+        get() = when (termsType) {
+            TermsType.SERVICE -> "https://malleable-pisces-00d.notion.site/2751852bf7c08048b62ddba00e687924"
+            TermsType.PRIVACY -> "https://malleable-pisces-00d.notion.site/2751852bf7c08027a6d4f0b60e20a605"
+        }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun TermsWebViewRoute(
+    onBack: () -> Unit,
+    viewModel: TermsViewModel = hiltViewModel()
+) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val webView = androidx.compose.runtime.remember {
+        WebView(context).apply {
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            webViewClient = WebViewClient()
+            settings.javaScriptEnabled = true
+            settings.domStorageEnabled = true
+            settings.setSupportMultipleWindows(false)
+            settings.loadsImagesAutomatically = true
+            settings.useWideViewPort = true
+            settings.allowFileAccess = false
+            settings.allowContentAccess = true
+        }
+    }
+
+    androidx.activity.compose.BackHandler(enabled = true) {
+        if (webView.canGoBack()) webView.goBack() else onBack()
+    }
+
+    androidx.compose.runtime.DisposableEffect(Unit) {
+        onDispose { webView.destroy() }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(id = viewModel.titleResId)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(StudifyString.back))
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Box(Modifier.fillMaxSize().padding(paddingValues)) {
+            AndroidView(
+                factory = { webView },
+                update = { it.loadUrl(viewModel.url) }
+            )
+        }
+    }
+}

--- a/feature/signup/src/main/java/com/ds/studify/feature/signup/navigation/SignupNavigation.kt
+++ b/feature/signup/src/main/java/com/ds/studify/feature/signup/navigation/SignupNavigation.kt
@@ -1,21 +1,39 @@
 package com.ds.studify.feature.signup.navigation
 
+import androidx.annotation.Keep
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.ds.studify.feature.signup.SignupRoute
+import com.ds.studify.feature.signup.TermsWebViewRoute
 import kotlinx.serialization.Serializable
 
 @Serializable
 data object RouteSignup
 
-fun NavGraphBuilder.signupScreen(
+@Serializable
+data class RouteTerms(val type: TermsType)
+
+@Keep
+@Serializable
+enum class TermsType {
+    SERVICE, PRIVACY
+}
+
+fun NavGraphBuilder.signupGraph(
+    navController: NavController,
     onNavigateLogin: () -> Unit
 ) {
     composable<RouteSignup> {
         SignupRoute(
-            onNavigateLogin = onNavigateLogin
+            onNavigateLogin = onNavigateLogin,
+            onNavigateTerms = { termsType ->
+                navController.navigate(RouteTerms(termsType))
+            }
         )
+    }
+    composable<RouteTerms> {
+        TermsWebViewRoute(onBack = { navController.popBackStack() })
     }
 }
 


### PR DESCRIPTION
## #️⃣ Issue
- Closes #86 

## ✅ 작업 상세 내용
- 모두 동의, 개인정보 처리방침, 서비스 이용약관, 만 14세 이상 약관 동의 체크 박스 추가
- 보기 선택 시 외부 링크 연결
- 모든 필수 약관 동의 시 회원 가입 버튼 활성화

## 📸 스크린샷
<img width="200px" src="https://github.com/user-attachments/assets/8839b624-8590-4391-9693-d77e85ce496b" />
<img width="200px" src="https://github.com/user-attachments/assets/82eb374c-6374-4fd9-8765-56aff36cb6ed" />
<img width="200px" src="https://github.com/user-attachments/assets/f4c21506-e119-415d-96f0-3bbae162e3b2" />

## 💬 참고 사항
외부 링크 내용 변경 가능성 존재합니다.